### PR TITLE
Don't try to parse error message

### DIFF
--- a/scripts/deploy_cli_auth0_actions.py
+++ b/scripts/deploy_cli_auth0_actions.py
@@ -24,7 +24,7 @@ def generate_binding(action_name):
 def fail_on_error(response):
   if response.status_code != 200:
     raise RuntimeError(
-      f"Failed to deploy action: {response.status_code} {response.json()['message']}")
+      f"Failed to deploy action: {response.status_code}")
 
 
 # ===== start


### PR DESCRIPTION
On error, print the response status code without attempting to parse any of the contents of the response.